### PR TITLE
Fix bootstrapping problem with UserProfile.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog of ddsc-site
 0.1 (unreleased)
 ----------------
 
-- Added lizard-wms.
+- Fix bootstrapping problem with UserProfile.
+
+- Added lizard-wms. (Wish you didn't!)
 
 - Added settings for staging site.
 


### PR DESCRIPTION
Initially, when applying syncdb, there is no ddsc_site_userprofile table yet, making the createsuperuser command fail. This problem is addressed by checking the existence of the table first. (An alternative would be to defer the creation of an admin account until all database migrations have been applied.)
